### PR TITLE
Change method signature so that storage layer doesn't need to understand buckets

### DIFF
--- a/storage_bolt.go
+++ b/storage_bolt.go
@@ -127,8 +127,12 @@ type boltReaderWriter struct {
 	Tx *bolt.Tx
 }
 
-func (db *boltReaderWriter) Get(ctx context.Context, bucket, key []byte, value proto.Message) error {
-	b := db.Tx.Bucket(bucket)
+var (
+	rootBucket = []byte("root")
+)
+
+func (db *boltReaderWriter) Get(ctx context.Context, key []byte, value proto.Message) error {
+	b := db.Tx.Bucket(rootBucket)
 	if b == nil {
 		return ErrNoSuchKey
 	}
@@ -139,8 +143,8 @@ func (db *boltReaderWriter) Get(ctx context.Context, bucket, key []byte, value p
 	return proto.Unmarshal(rv, value)
 }
 
-func (db *boltReaderWriter) Set(ctx context.Context, bucket, key []byte, value proto.Message) error {
-	b, err := db.Tx.CreateBucketIfNotExists(bucket)
+func (db *boltReaderWriter) Set(ctx context.Context, key []byte, value proto.Message) error {
+	b, err := db.Tx.CreateBucketIfNotExists(rootBucket)
 	if err != nil {
 		return err
 	}

--- a/storage_headers.go
+++ b/storage_headers.go
@@ -43,7 +43,7 @@ type StorageWriter interface {
 type KeyReader interface {
 	// Get reads the value for key in a bucket into a proto.
 	// It must return nil, ErrNoSuchKey if none found
-	Get(ctx context.Context, bucket, key []byte, value proto.Message) error
+	Get(ctx context.Context, key []byte, value proto.Message) error
 }
 
 // KeyWriter allows write access to a namespace
@@ -51,5 +51,5 @@ type KeyWriter interface {
 	KeyReader
 
 	// Set sets the thing. Value of nil means delete.
-	Set(ctx context.Context, bucket, key []byte, value proto.Message) error
+	Set(ctx context.Context, key []byte, value proto.Message) error
 }

--- a/storage_memory.go
+++ b/storage_memory.go
@@ -74,23 +74,22 @@ type memoryThing struct {
 	Data map[string][]byte
 }
 
-func (db *memoryThing) Get(ctx context.Context, bucket, key []byte, value proto.Message) error {
+func (db *memoryThing) Get(ctx context.Context, key []byte, value proto.Message) error {
 	if db.Data == nil {
 		return ErrNoSuchKey
 	}
-	actKey := string(bucket) + "|" + string(key) // TODO, fix to something guaranteed to be unique
-	rv, ok := db.Data[actKey]
+	rv, ok := db.Data[string(key)]
 	if !ok { // as distinct from 0 length
 		return ErrNoSuchKey
 	}
 	return proto.Unmarshal(rv, value)
 }
 
-func (db *memoryThing) Set(ctx context.Context, bucket, key []byte, value proto.Message) error {
+func (db *memoryThing) Set(ctx context.Context, key []byte, value proto.Message) error {
 	if db.Data == nil {
 		return ErrNotImplemented
 	}
-	actKey := string(bucket) + "|" + string(key) // TODO, fix to something guaranteed to be unique
+	actKey := string(key)
 	if value == nil {
 		delete(db.Data, actKey)
 		return nil


### PR DESCRIPTION
This should make it easier to add additional storage layers such as [Badger](https://github.com/continusec/verifiabledatastructures/pull/4).

Note this would break reading existing Bolt files. We'd need to write a small migrate tool - which should be easy enough to do, but I'll wait to hear if it's needed.

As far as I'm aware, we're the only current users of the library.